### PR TITLE
Bug/Feat: [PV-11] Refine User and Trip model tests and add password module to new security package

### DIFF
--- a/planventure-api/models/base.py
+++ b/planventure-api/models/base.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
@@ -8,5 +8,10 @@ class BaseModel(db.Model):
     """Base model with common attributes."""
 
     __abstract__ = True
-    created_at = db.Column(db.DateTime, default=datetime.now)
-    updated_at = db.Column(db.DateTime, default=datetime.now, onupdate=datetime.now)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = db.Column(db.DateTime, onupdate=lambda: datetime.now(timezone.utc))
+
+    def __init__(self):
+        super().__init__()
+        self.created_at = datetime.now(timezone.utc)
+        self.updated_at = None

--- a/planventure-api/models/trip.py
+++ b/planventure-api/models/trip.py
@@ -42,19 +42,25 @@ class Trip(BaseModel):
         description=None,
     ):
         """Initialize a Trip instance with validation."""
+        super().__init__()
         if start_date >= end_date:
             raise ValueError("start_date must be before end_date")
         if latitude is not None and (latitude < -90 or latitude > 90):
-            raise ValueError("latitude must be between -90 and 90")
+            raise ValueError("latitude must be between -90 and 90 when defined")
         if longitude is not None and (longitude < -180 or longitude > 180):
-            raise ValueError("longitude must be between -180 and 180")
+            raise ValueError("longitude must be between -180 and 180 when defined")
+        if (longitude is not None and latitude is None) or (
+            latitude is not None and longitude is None
+        ):
+            raise ValueError("Both latitude and longitude must be provided together")
         self.title = title
         self.description = description
+        self.destination = (
+            destination or "Unknown"
+        )  # TBD derivation when latlong provided
         self.user_id = user_id
         self.start_date = start_date
         self.end_date = end_date
         self.latitude = latitude
         self.longitude = longitude
         self.itinerary = itinerary or {}
-        self.created_at = datetime.now()
-        self.updated_at = datetime.now()

--- a/planventure-api/models/trip.py
+++ b/planventure-api/models/trip.py
@@ -1,5 +1,5 @@
 from .base import BaseModel, db
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class Trip(BaseModel):
@@ -17,6 +17,11 @@ class Trip(BaseModel):
     latitude = db.Column(db.Float, nullable=True)
     longitude = db.Column(db.Float, nullable=True)
     itinerary = db.Column(db.JSON)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = db.Column(
+        db.DateTime,
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
 
     # Relationship
     user = db.relationship("User", back_populates="trips")

--- a/planventure-api/models/user.py
+++ b/planventure-api/models/user.py
@@ -1,7 +1,7 @@
 import re
-import bcrypt
 from .base import BaseModel, db
 from datetime import datetime, timezone
+from utils.security import hash_password, verify_password
 
 
 class User(BaseModel):
@@ -12,12 +12,8 @@ class User(BaseModel):
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(120), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
+    password_salt = db.Column(db.String(128), nullable=False)
     is_active = db.Column(db.Boolean, default=True, nullable=False)
-    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
-    updated_at = db.Column(
-        db.DateTime,
-        onupdate=lambda: datetime.now(timezone.utc),
-    )
 
     # Add relationship
     trips = db.relationship("Trip", back_populates="user", lazy="dynamic")
@@ -32,20 +28,21 @@ class User(BaseModel):
         if not self.validate_email(email):
             raise ValueError("Invalid email format")
         self.email = email
-        self.set_password(password)
+        self.__init_password(password)
         self.is_active = True
 
-    def set_password(self, password):
+    def __init_password(self, password):
         """Hashes the password and stores it."""
-        self.password_hash = bcrypt.hashpw(
-            password.encode("utf-8"), bcrypt.gensalt()
-        ).decode("utf-8")
+        self.password_hash, self.password_salt = hash_password(password)
 
-    def authenticate(self, plaintext_password):
-        """Verifies the plaintext password against the stored hash."""
-        return bcrypt.checkpw(
-            plaintext_password.encode("utf-8"), self.password_hash.encode("utf-8")
-        )
+    def set_password(self, password):
+        """Hashes the password and updates it."""
+        self.password_hash, self.password_salt = hash_password(password)
+        self.updated_at = datetime.now(timezone.utc)
+
+    def authenticate(self, password: str) -> bool:
+        """Verify the provided password against stored hash."""
+        return verify_password(password, self.password_hash)
 
     @staticmethod
     def validate_email(email: str) -> bool:

--- a/planventure-api/models/user.py
+++ b/planventure-api/models/user.py
@@ -1,7 +1,7 @@
 import re
 import bcrypt
 from .base import BaseModel, db
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class User(BaseModel):
@@ -13,6 +13,11 @@ class User(BaseModel):
     email = db.Column(db.String(120), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
     is_active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = db.Column(
+        db.DateTime,
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
 
     # Add relationship
     trips = db.relationship("Trip", back_populates="user", lazy="dynamic")

--- a/planventure-api/tests/test_security.py
+++ b/planventure-api/tests/test_security.py
@@ -1,0 +1,40 @@
+import pytest
+from utils.security import hash_password, verify_password, generate_salt
+
+
+def test_password_hashing():
+    """Test password hashing and verification."""
+    password = "mysecretpassword123"
+
+    # Test basic hashing
+    hashed, salt = hash_password(password)
+    assert hashed != password.encode("utf-8")
+    assert salt is not None
+    assert verify_password(password, hashed) is True
+    assert verify_password("wrongpassword", hashed) is False
+
+    # Test consistency with same salt
+    hashed1, salt = hash_password(password)
+    hashed2, _ = hash_password(password, salt)
+    assert hashed1 == hashed2
+
+    # Test different salts produce different hashes
+    hashed3, salt3 = hash_password(password)
+    assert hashed1 != hashed3
+    assert salt != salt3
+
+
+def test_verify_password_with_invalid_hash():
+    """Test password verification with invalid hash."""
+    assert verify_password("password123", b"invalid_hash") is False
+    assert verify_password("password123", b"") is False
+
+
+def test_salt_generation():
+    """Test salt generation."""
+    salt1 = generate_salt()
+    salt2 = generate_salt()
+    assert salt1 != salt2
+    assert len(salt1) > 16  # Ensure sufficient salt length
+    assert isinstance(salt1, bytes)
+    assert isinstance(salt2, bytes)

--- a/planventure-api/tests/test_trip.py
+++ b/planventure-api/tests/test_trip.py
@@ -89,6 +89,28 @@ def test_trip_attributes(sample_trip):
     assert hasattr(sample_trip, "longitude")  # New attribute
 
 
+def test_trip_latlong_together_validation(sample_user):
+    """Test that Trip raises ValueError if only one of latitude or longitude is provided."""
+    with pytest.raises(ValueError):
+        Trip(
+            title="Invalid Trip",
+            description="Trip with only latitude",
+            start_date=datetime.now() + timedelta(days=5),
+            end_date=datetime.now(),
+            user_id=sample_user.id,
+            latitude=45.0,  # Only latitude provided
+        )
+    with pytest.raises(ValueError):
+        Trip(
+            title="Invalid Trip",
+            description="Trip with only longitude",
+            start_date=datetime.now() + timedelta(days=5),
+            end_date=datetime.now(),
+            user_id=sample_user.id,
+            longitude=90.0,  # Only longitude provided
+        )
+
+
 def test_trip_user_relationship(sample_trip, sample_user):
     """Test the relationship between Trip and User."""
     assert sample_trip.user_id == sample_user.id

--- a/planventure-api/tests/test_user.py
+++ b/planventure-api/tests/test_user.py
@@ -1,6 +1,9 @@
 # Import sys module for modifying Python's runtime environment
 import sys
 
+# Import copy for copying datetime objects
+from copy import copy
+
 # Import os module for interacting with the operating system
 import os
 
@@ -20,7 +23,41 @@ def test_user_creation():
     user = User(email="test@example.com", password="password123")
     assert user.email == "test@example.com"
     assert user.is_active is True
-    assert user.password_hash != "password123"  # Password should be hashed
+    assert user.password_hash is not None
+    assert user.password_salt is not None
+    assert isinstance(user.created_at, datetime)
+    assert isinstance(user.updated_at, datetime) or user.updated_at is None
+
+
+def test_password_update():
+    """Test updating user password."""
+    user = User(email="test@example.com", password="password123")
+    original_hash = user.password_hash
+    original_updated_at = user.updated_at
+    assert original_updated_at is None
+
+    # Wait a moment to ensure timestamp difference
+    import time
+
+    time.sleep(0.1)
+
+    # Update password and check changes
+    user.set_password("newpassword456")
+    assert user.password_hash != original_hash
+    assert user.updated_at is not None
+    updated_hash = user.password_hash
+    updated_updated_at = user.updated_at
+
+    # Wait and update again to check updated_at changes
+    time.sleep(0.1)
+    user.set_password("newpassword789")
+    assert user.password_hash != updated_hash
+    assert user.updated_at is not None
+    assert user.updated_at > updated_updated_at
+
+    # Verify authentication with new and old passwords
+    assert user.authenticate("newpassword789") is True
+    assert user.authenticate("password123") is False
 
 
 def test_user_authentication():
@@ -39,6 +76,15 @@ def test_user_attributes():
     assert hasattr(user, "is_active")
     assert hasattr(user, "created_at")
     assert hasattr(user, "updated_at")
+
+
+def test_password_related_attributes():
+    """Test password-related attributes and methods."""
+    user = User(email="test@example.com", password="password123")
+    assert hasattr(user, "password_hash")
+    assert hasattr(user, "password_salt")
+    assert hasattr(user, "authenticate")
+    assert hasattr(user, "set_password")
 
 
 def test_email_validation():

--- a/planventure-api/utils/security/__init__.py
+++ b/planventure-api/utils/security/__init__.py
@@ -1,0 +1,3 @@
+from .password import hash_password, verify_password, generate_salt
+
+__all__ = ["hash_password", "verify_password", "generate_salt"]

--- a/planventure-api/utils/security/password.py
+++ b/planventure-api/utils/security/password.py
@@ -1,0 +1,32 @@
+import bcrypt
+from typing import Tuple
+
+
+def generate_salt() -> bytes:
+    """Generate a random salt for password hashing."""
+    return bcrypt.gensalt()
+
+
+def hash_password(password: str, salt: bytes = None) -> Tuple[bytes, bytes]:
+    """
+    Hash a password with a salt. If no salt is provided, generate one.
+    Returns a tuple of (hashed_password, salt).
+    """
+    if not salt:
+        salt = generate_salt()
+
+    password_bytes = password.encode("utf-8")
+    hashed = bcrypt.hashpw(password_bytes, salt)
+    return hashed, salt
+
+
+def verify_password(password: str, hashed_password: bytes) -> bool:
+    """
+    Verify a password against its hash.
+    Returns True if password matches, False otherwise.
+    """
+    password_bytes = password.encode("utf-8")
+    try:
+        return bcrypt.checkpw(password_bytes, hashed_password)
+    except Exception:
+        return False


### PR DESCRIPTION
## Summary

This updates the bug such that setting a new password in a User model instance does not set the updated_at field. It also addresses refactoring and tests to support better validation upon initialization of the Trip model, and delegation of created_at and updated_at fields to the parent BaseModel class.

To better prepare the User module for ticket #10, a password module has been added into this ticket as well. 

## Issue Link

Issue ticket #11 [PV-11](https://github.com/sanchezelton/planventure/issues/11).

Related ticket: #10 [PV-10](https://github.com/sanchezelton/planventure/issues/10) 

## Root Cause Analysis for bug

Initialization of the updated_at field was not properly delegated from the implementing models for either User or Trip models into the parent BaseModel class. A manual analysis of the tables in the DB when running existing tests noted the possibility and a new test was written to detect the bug.

Further code review/analysis showed deficiencies in timezone and latlong validation. 

## Changes for bug

Delegation and initialization properly implemented. Latlong validation implemented. Additional tests written to test validation.

## Changes for feature

Password module added under a new package `security`.

## Impact

No other parts of the API should be affected by this change.

## Testing Strategy

No other models or endpoints exists or implement at the moment of writing any of the models.

## Regression Risk

No risk of regression with the given models at this time.

## Checklist

- [x] The fix has been locally tested

- [x] New unit tests have been added to prevent future regressions

- ~~[ ] The documentation has been updated if necessary~~

## Additional Notes

N/A